### PR TITLE
Enable granular product embeddings

### DIFF
--- a/src/Service/EmbeddingGeneratorInterface.php
+++ b/src/Service/EmbeddingGeneratorInterface.php
@@ -7,12 +7,17 @@ use App\Entity\Product;
 interface EmbeddingGeneratorInterface
 {
     /**
-     * Generates an embedding vector for the given product.
+     * Generate embeddings for the different parts of a product.
      *
-     * @param Product $product The product entity to generate an embedding for.
-     * @return array<int, float> Embedding vector representing the product.
+     * Each returned item must contain the embedding vector and the type of the
+     * processed chunk (e.g. "specification", "feature", "description", or
+     * "generic").
+     *
+     * @param Product $product The product entity to generate embeddings for.
+     * @return array<int, array{vector: array<int, float>, type: string}> List of
+     *         embeddings with their type.
      */
-    public function generateEmbedding(Product $product): array;
+    public function generateProductEmbeddings(Product $product): array;
 
     /**
      * Generates an embedding vector for the given search query.

--- a/src/Service/VectorStoreInterface.php
+++ b/src/Service/VectorStoreInterface.php
@@ -30,11 +30,21 @@ interface VectorStoreInterface
     
     /**
      * Insert multiple products into the vector database
-     * 
+     *
      * @param array<int, Product> $products Array of Product objects to insert
      * @return bool True if all insertions were successful, false if any failed
      */
     public function insertProducts(array $products): bool;
+
+    /**
+     * Insert all chunk embeddings of a single product.
+     *
+     * @param Product $product The product being processed
+     * @param array<int, array{vector: array<int, float>, type: string}> $chunks
+     *        Embedding data for the product
+     * @return bool True on success, false on failure
+     */
+    public function insertProductChunks(Product $product, array $chunks): bool;
     
     /**
      * Search for products similar to the provided query embedding


### PR DESCRIPTION
## Summary
- generate embeddings for every relevant text and image chunk of a product
- store product chunks in Milvus along with product metadata
- update CLI import command to use the new embedding logic
- adjust interfaces accordingly

## Testing
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859097a0b4883319e13366df4b3f89f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced product import process to generate and store multiple types of embeddings (text segments and images) for each product.
  - Embeddings are now immediately inserted into the vector store as they are generated, improving efficiency and progress tracking.
  - Added support for incremental insertion of product embedding chunks into the vector store.

- **Improvements**
  - Progress bar now reflects the entire import process, including both embedding generation and insertion.
  - Expanded embedding generation to handle various product segments and images, resulting in more comprehensive search and retrieval capabilities.
  - Improved error handling and logging for embedding generation and insertion processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->