### PR TITLE
Add microphone speech-to-text using OpenAI

### DIFF
--- a/.env
+++ b/.env
@@ -28,3 +28,6 @@ MILVUS_TOKEN="root:"
 
 APP_EMBED_HOST=http://localhost
 EMBED_PORT=5000
+
+# Model used for OpenAI speech-to-text (Whisper)
+OPENAI_STT_MODEL=whisper-1

--- a/.env.dist
+++ b/.env.dist
@@ -28,3 +28,6 @@ MILVUS_TOKEN="root:"
 
 APP_EMBED_HOST=http://localhost
 EMBED_PORT=5000
+
+# Model used for OpenAI speech-to-text (Whisper)
+OPENAI_STT_MODEL=whisper-1

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -71,3 +71,13 @@ services:
     App\Command\ProcessImageCommand:
         arguments:
             $embeddingGenerator: '@App\Service\PythonEmbeddingGenerator'
+
+    App\Service\OpenAISpeechToTextService:
+        arguments:
+            $model: '%env(OPENAI_STT_MODEL)%'
+
+    App\Service\SpeechToTextServiceInterface: '@App\Service\OpenAISpeechToTextService'
+
+    App\Command\ProcessAudioCommand:
+        arguments:
+            $sttService: '@App\Service\OpenAISpeechToTextService'

--- a/src/Command/ProcessAudioCommand.php
+++ b/src/Command/ProcessAudioCommand.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace App\\Command;
+namespace App\Command;
 
-use App\\Service\\SpeechToTextServiceInterface;
-use Symfony\\Component\\Console\\Attribute\\AsCommand;
-use Symfony\\Component\\Console\\Command\\Command;
-use Symfony\\Component\\Console\\Input\\ArrayInput;
-use Symfony\\Component\\Console\\Input\\InputArgument;
-use Symfony\\Component\\Console\\Input\\InputInterface;
-use Symfony\\Component\\Console\\Output\\OutputInterface;
-use Symfony\\Component\\Console\\Style\\SymfonyStyle;
+use App\Service\SpeechToTextServiceInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 #[AsCommand(
     name: 'app:process-audio',

--- a/src/Command/ProcessAudioCommand.php
+++ b/src/Command/ProcessAudioCommand.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\\Command;
+
+use App\\Service\\SpeechToTextServiceInterface;
+use Symfony\\Component\\Console\\Attribute\\AsCommand;
+use Symfony\\Component\\Console\\Command\\Command;
+use Symfony\\Component\\Console\\Input\\ArrayInput;
+use Symfony\\Component\\Console\\Input\\InputArgument;
+use Symfony\\Component\\Console\\Input\\InputInterface;
+use Symfony\\Component\\Console\\Output\\OutputInterface;
+use Symfony\\Component\\Console\\Style\\SymfonyStyle;
+
+#[AsCommand(
+    name: 'app:process-audio',
+    description: 'Transcribe an audio file and search products based on the text',
+)]
+class ProcessAudioCommand extends Command
+{
+    private SpeechToTextServiceInterface $sttService;
+
+    public function __construct(SpeechToTextServiceInterface $sttService)
+    {
+        parent::__construct();
+        $this->sttService = $sttService;
+    }
+
+    protected function configure(): void
+    {
+        $this->addArgument('audio', InputArgument::REQUIRED, 'Path to the audio file');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $audioPath = $input->getArgument('audio');
+
+        if (!is_file($audioPath)) {
+            $io->error('Audio file not found: ' . $audioPath);
+            return Command::FAILURE;
+        }
+
+        try {
+            $text = $this->sttService->transcribe($audioPath);
+
+            if ($text === null || $text === '') {
+                $io->error('Transcription failed or empty');
+                return Command::FAILURE;
+            }
+
+            $io->text('Transcribed text: ' . $text);
+
+            $application = $this->getApplication();
+            if (!$application) {
+                $io->error('Console application not available');
+                return Command::FAILURE;
+            }
+
+            $command = $application->find('app:test-search');
+            $arguments = [
+                'command' => 'app:test-search',
+                'query' => $text,
+            ];
+            $testInput = new ArrayInput($arguments);
+            $testInput->setInteractive(false);
+
+            return $command->run($testInput, $output);
+        } catch (\Throwable $e) {
+            $io->error('An error occurred: ' . $e->getMessage());
+            return Command::FAILURE;
+        }
+    }
+}
+

--- a/src/Controller/WebInterfaceController.php
+++ b/src/Controller/WebInterfaceController.php
@@ -22,7 +22,6 @@ class WebInterfaceController extends AbstractController
     private const MAX_IMAGE_SIZE = 5242880; // 5 MB
     private const ALLOWED_IMAGE_TYPES = ['image/jpeg', 'image/png'];
     private const MAX_AUDIO_SIZE = 5242880; // 5 MB
-    private const ALLOWED_AUDIO_TYPES = ['audio/mpeg', 'audio/wav', 'audio/webm'];
     #[Route('/', name: 'app_home')]
     public function index(): Response
     {
@@ -109,7 +108,8 @@ class WebInterfaceController extends AbstractController
             return new JsonResponse(['success' => false, 'message' => 'No audio uploaded'], 400);
         }
 
-        if (!in_array($file->getMimeType(), self::ALLOWED_AUDIO_TYPES, true)) {
+        $mimeType = $file->getMimeType() ?? '';
+        if (!str_starts_with($mimeType, 'audio/') && $mimeType !== 'video/webm') {
             return new JsonResponse(['success' => false, 'message' => 'Invalid audio type'], 400);
         }
 

--- a/src/Service/OpenAISpeechToTextService.php
+++ b/src/Service/OpenAISpeechToTextService.php
@@ -41,13 +41,6 @@ class OpenAISpeechToTextService implements SpeechToTextServiceInterface
                 'response_format' => 'json',
             ]);
 
-            if (is_array($response) && isset($response['text'])) {
-                $this->logger->info('Received transcription from OpenAI Whisper', [
-                    'length' => strlen($response['text']),
-                ]);
-                return $response['text'];
-            }
-
             if (is_object($response) && isset($response->text)) {
                 $this->logger->info('Received transcription from OpenAI Whisper', [
                     'length' => strlen($response->text),

--- a/src/Service/OpenAISpeechToTextService.php
+++ b/src/Service/OpenAISpeechToTextService.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\\Service;
+
+use OpenAI\\Client;
+use Psr\\Log\\LoggerInterface;
+
+/**
+ * Service for performing speech-to-text using OpenAI Whisper API.
+ */
+class OpenAISpeechToTextService implements SpeechToTextServiceInterface
+{
+    private Client $client;
+    private LoggerInterface $logger;
+    private string $model;
+
+    public function __construct(Client $client, LoggerInterface $logger, string $model = 'whisper-1')
+    {
+        $this->client = $client;
+        $this->logger = $logger;
+        $this->model = $model;
+    }
+
+    public function transcribe(string $audioPath): ?string
+    {
+        if (!is_file($audioPath)) {
+            $this->logger->error('Audio file not found for transcription', ['path' => $audioPath]);
+            return null;
+        }
+
+        try {
+            $this->logger->info('Sending audio file to OpenAI Whisper', ['model' => $this->model]);
+
+            $response = $this->client->audio()->transcribe([
+                'model' => $this->model,
+                'file' => fopen($audioPath, 'r'),
+                'response_format' => 'json',
+            ]);
+
+            if (is_array($response) && isset($response['text'])) {
+                return $response['text'];
+            }
+
+            if (is_object($response) && isset($response->text)) {
+                return $response->text;
+            }
+
+            $this->logger->error('Invalid response format from OpenAI Whisper', ['response' => $response]);
+            return null;
+        } catch (\Throwable $e) {
+            $this->logger->error('Error during OpenAI Whisper transcription', [
+                'exception' => $e,
+            ]);
+            return null;
+        }
+    }
+}
+

--- a/src/Service/OpenAISpeechToTextService.php
+++ b/src/Service/OpenAISpeechToTextService.php
@@ -41,7 +41,7 @@ class OpenAISpeechToTextService implements SpeechToTextServiceInterface
                 'response_format' => 'json',
             ]);
 
-            if (is_object($response) && isset($response->text)) {
+            if (isset($response->text)) {
                 $this->logger->info('Received transcription from OpenAI Whisper', [
                     'length' => strlen($response->text),
                 ]);

--- a/src/Service/OpenAISpeechToTextService.php
+++ b/src/Service/OpenAISpeechToTextService.php
@@ -29,7 +29,11 @@ class OpenAISpeechToTextService implements SpeechToTextServiceInterface
         }
 
         try {
-            $this->logger->info('Sending audio file to OpenAI Whisper', ['model' => $this->model]);
+            $this->logger->info('Sending audio file to OpenAI Whisper', [
+                'model' => $this->model,
+                'path' => $audioPath,
+                'size' => filesize($audioPath),
+            ]);
 
             $response = $this->client->audio()->transcribe([
                 'model' => $this->model,
@@ -38,10 +42,16 @@ class OpenAISpeechToTextService implements SpeechToTextServiceInterface
             ]);
 
             if (is_array($response) && isset($response['text'])) {
+                $this->logger->info('Received transcription from OpenAI Whisper', [
+                    'length' => strlen($response['text']),
+                ]);
                 return $response['text'];
             }
 
             if (is_object($response) && isset($response->text)) {
+                $this->logger->info('Received transcription from OpenAI Whisper', [
+                    'length' => strlen($response->text),
+                ]);
                 return $response->text;
             }
 

--- a/src/Service/OpenAISpeechToTextService.php
+++ b/src/Service/OpenAISpeechToTextService.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace App\\Service;
+namespace App\Service;
 
-use OpenAI\\Client;
-use Psr\\Log\\LoggerInterface;
+use OpenAI\Client;
+use Psr\Log\LoggerInterface;
 
 /**
  * Service for performing speech-to-text using OpenAI Whisper API.

--- a/src/Service/SpeechToTextServiceInterface.php
+++ b/src/Service/SpeechToTextServiceInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\\Service;
+namespace App\Service;
 
 /**
  * Interface for converting speech audio to text.

--- a/src/Service/SpeechToTextServiceInterface.php
+++ b/src/Service/SpeechToTextServiceInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\\Service;
+
+/**
+ * Interface for converting speech audio to text.
+ */
+interface SpeechToTextServiceInterface
+{
+    /**
+     * Transcribe the given audio file to text.
+     *
+     * @param string $audioPath Path to the audio file.
+     * @return string|null The transcribed text or null on failure.
+     */
+    public function transcribe(string $audioPath): ?string;
+}
+

--- a/templates/home/index.html.twig
+++ b/templates/home/index.html.twig
@@ -22,6 +22,7 @@
                         <div class="input-group mb-2">
                             <input type="text" id="user-input" class="form-control" placeholder="z.B. Ich suche ein wasserdichtes Smartphone mit guter Kamera...">
                             <button class="btn btn-primary" id="send-button">Suchen</button>
+                            <button class="btn btn-secondary" id="record-button">Sprache aufnehmen</button>
                         </div>
                         <div class="input-group">
                             <input type="file" id="image-input" class="form-control" accept="image/*">
@@ -84,6 +85,7 @@
         const chatMessages = document.getElementById('chat-messages');
         const userInput = document.getElementById('user-input');
         const sendButton = document.getElementById('send-button');
+        const recordButton = document.getElementById('record-button');
         const imageInput = document.getElementById('image-input');
         const uploadButton = document.getElementById('upload-button');
         const openCameraButton = document.getElementById('open-camera-button');
@@ -91,6 +93,8 @@
         const videoPreview = document.getElementById('video-preview');
         const captureButton = document.getElementById('capture-button');
         let cameraStream = null;
+        let mediaRecorder = null;
+        let recordedChunks = [];
         if (navigator.mediaDevices && navigator.mediaDevices.enumerateDevices) {
             navigator.mediaDevices.enumerateDevices().then(devices => {
                 if (devices.some(d => d.kind === 'videoinput')) {
@@ -168,6 +172,33 @@
                 addMessage('Es ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut.', false);
             });
         }
+
+        function searchAudio(blob) {
+            if (!blob) {
+                return;
+            }
+            addMessage('Audio wird verarbeitet...', false);
+
+            const formData = new FormData();
+            formData.append('audio', blob, 'recording.webm');
+
+            fetch('/search/audio', {
+                method: 'POST',
+                body: formData
+            })
+            .then(response => response.json())
+            .then(data => {
+                if (data.success) {
+                    addMessage(`<pre>${data.output}</pre>`, false);
+                } else {
+                    addMessage('Es ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut.', false);
+                }
+            })
+            .catch(error => {
+                console.error('Error:', error);
+                addMessage('Es ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut.', false);
+            });
+        }
         
         function displayProducts(products) {
             productResults.innerHTML = '';
@@ -203,6 +234,34 @@
                 addMessage(query, true);
                 userInput.value = '';
                 searchProducts(query);
+            }
+        });
+
+        recordButton.addEventListener('click', function() {
+            if (mediaRecorder && mediaRecorder.state === 'recording') {
+                mediaRecorder.stop();
+                recordButton.textContent = 'Sprache aufnehmen';
+            } else {
+                if (navigator.mediaDevices && navigator.mediaDevices.getUserMedia) {
+                    navigator.mediaDevices.getUserMedia({ audio: true }).then(stream => {
+                        recordedChunks = [];
+                        mediaRecorder = new MediaRecorder(stream);
+                        mediaRecorder.ondataavailable = e => {
+                            if (e.data.size > 0) {
+                                recordedChunks.push(e.data);
+                            }
+                        };
+                        mediaRecorder.onstop = () => {
+                            const blob = new Blob(recordedChunks, { type: 'audio/webm' });
+                            searchAudio(blob);
+                            stream.getTracks().forEach(t => t.stop());
+                        };
+                        mediaRecorder.start();
+                        recordButton.textContent = 'Stoppen';
+                    }).catch(err => {
+                        console.error('Audio error', err);
+                    });
+                }
             }
         });
 

--- a/templates/home/index.html.twig
+++ b/templates/home/index.html.twig
@@ -86,6 +86,10 @@
         const userInput = document.getElementById('user-input');
         const sendButton = document.getElementById('send-button');
         const recordButton = document.getElementById('record-button');
+        const canRecord = typeof MediaRecorder !== 'undefined';
+        if (!canRecord) {
+            recordButton.style.display = 'none';
+        }
         const imageInput = document.getElementById('image-input');
         const uploadButton = document.getElementById('upload-button');
         const openCameraButton = document.getElementById('open-camera-button');
@@ -238,6 +242,10 @@
         });
 
         recordButton.addEventListener('click', function() {
+            if (!canRecord) {
+                alert('Dieser Browser unterstützt keine Audioaufnahme.');
+                return;
+            }
             if (mediaRecorder && mediaRecorder.state === 'recording') {
                 mediaRecorder.stop();
                 recordButton.textContent = 'Sprache aufnehmen';


### PR DESCRIPTION
## Summary
- expose `OPENAI_STT_MODEL` env var
- implement `SpeechToTextServiceInterface` and `OpenAISpeechToTextService`
- add console command `ProcessAudioCommand`
- allow `/search/audio` endpoint to handle recorded audio
- update web UI to record audio from the browser

## Testing
- `composer` **failed**: command not found
- `phpunit` **failed**: command not found
- `phpstan` **failed**: command not found

------
https://chatgpt.com/codex/tasks/task_e_685d4bde29fc8331abfbd86385233dd6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added speech-to-text search using OpenAI Whisper for voice-based queries.
  * Introduced a "Sprache aufnehmen" (Record Speech) button enabling direct audio recording in the chat.
  * Enabled audio file uploads (MP3, WAV, WEBM) up to 5 MB for search.
  * Added a console command for processing audio files and integrating transcription with search.

* **Bug Fixes**
  * Enhanced error handling and user feedback for audio upload and transcription issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->