### PR TITLE
Fetch Milvus dimension dynamically

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -33,11 +33,11 @@ services:
         arguments:
             $milvus: '@Milvus\Client'
             $logger: '@Psr\Log\LoggerInterface'
+            $embeddingService: '@App\Service\PythonEmbeddingService'
             $collectionName: '%env(MILVUS_COLLECTION)%' # e.g., "products"
-            $dimension: 1536 # Reverted to 768 based on Python service log output
 
     # New Python Embedding Service
-    App\Service\PythonEmbeddingGenerator:
+    App\Service\PythonEmbeddingService:
         arguments:
             $httpClient: '@Symfony\Contracts\HttpClient\HttpClientInterface'
             $logger: '@Psr\Log\LoggerInterface'
@@ -45,8 +45,8 @@ services:
             $embedHost: '%env(APP_EMBED_HOST)%' # Assuming http://localhost or similar
             $embedPort: '%env(EMBED_PORT)%'
 
-    # Bind the EmbeddingGeneratorInterface to the new PythonEmbeddingGenerator
-    App\Service\EmbeddingGeneratorInterface: '@App\Service\PythonEmbeddingGenerator'
+    # Bind the EmbeddingGeneratorInterface to the PythonEmbeddingService
+    App\Service\EmbeddingGeneratorInterface: '@App\Service\PythonEmbeddingService'
 
     # OpenAI client and embedding generator are removed as they are replaced.
     # App\Service\OpenAISearchService might still be needed if it's used for chat completion based on search results.
@@ -70,7 +70,7 @@ services:
 
     App\Command\ProcessImageCommand:
         arguments:
-            $embeddingGenerator: '@App\Service\PythonEmbeddingGenerator'
+            $embeddingGenerator: '@App\Service\PythonEmbeddingService'
 
     App\Service\OpenAISpeechToTextService:
         arguments:

--- a/src/Command/ProcessImageCommand.php
+++ b/src/Command/ProcessImageCommand.php
@@ -9,7 +9,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use App\Service\PythonEmbeddingGenerator;
+use App\Service\PythonEmbeddingService;
 
 #[AsCommand(
     name: 'app:process-image',
@@ -17,9 +17,9 @@ use App\Service\PythonEmbeddingGenerator;
 )]
 class ProcessImageCommand extends Command
 {
-    private PythonEmbeddingGenerator $embeddingGenerator;
+    private PythonEmbeddingService $embeddingGenerator;
 
-    public function __construct(PythonEmbeddingGenerator $embeddingGenerator)
+    public function __construct(PythonEmbeddingService $embeddingGenerator)
     {
         parent::__construct();
         $this->embeddingGenerator = $embeddingGenerator;

--- a/src/Service/MilvusVectorStoreService.php
+++ b/src/Service/MilvusVectorStoreService.php
@@ -5,6 +5,7 @@ namespace App\Service;
 use App\Entity\Product;
 use HelgeSverre\Milvus\Milvus as MilvusClient;
 use Psr\Log\LoggerInterface;
+use App\Service\PythonEmbeddingService;
 
 /**
  * Service for interacting with Milvus vector database
@@ -26,6 +27,11 @@ class MilvusVectorStoreService implements VectorStoreInterface
     private string $collectionName;
 
     /**
+     * Embedding service for dimension and embedding calls
+     */
+    private PythonEmbeddingService $embeddingService;
+
+    /**
      * Dimension of the vector embeddings
      */
     private int $dimension;
@@ -38,21 +44,22 @@ class MilvusVectorStoreService implements VectorStoreInterface
     /**
      * Constructor
      * 
-     * @param MilvusClient $milvus The Milvus client instance
+     * @param MilvusClient $milvus   The Milvus client instance
      * @param LoggerInterface $logger The logger service
+     * @param PythonEmbeddingService $embeddingService Service for embedding API calls
      * @param string $collectionName The name of the collection to use (default: 'default')
-     * @param int $dimension The dimension of the vector embeddings (default: 1536)
      */
     public function __construct(
         MilvusClient $milvus,
         LoggerInterface $logger,
-        string $collectionName = 'default',
-        int $dimension = 1536 // Reverted default to 768
+        PythonEmbeddingService $embeddingService,
+        string $collectionName = 'default'
     ) {
         $this->milvus = $milvus;
         $this->logger = $logger;
+        $this->embeddingService = $embeddingService;
         $this->collectionName = $collectionName;
-        $this->dimension = $dimension;
+        $this->dimension = $this->embeddingService->getVectorDimension();
     }
 
     /**

--- a/tests/ProcessImageCommandTest.php
+++ b/tests/ProcessImageCommandTest.php
@@ -3,7 +3,7 @@
 namespace App\Tests;
 
 use App\Command\ProcessImageCommand;
-use App\Service\PythonEmbeddingGenerator;
+use App\Service\PythonEmbeddingService;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
@@ -16,7 +16,7 @@ class ProcessImageCommandTest extends TestCase
 {
     public function testExecuteRunsSearchCommandWithDescription(): void
     {
-        $generator = $this->createMock(PythonEmbeddingGenerator::class);
+        $generator = $this->createMock(PythonEmbeddingService::class);
         $generator->expects($this->once())
             ->method('describeImage')
             ->willReturn('awesome phone');
@@ -55,7 +55,7 @@ class ProcessImageCommandTest extends TestCase
 
     public function testExecuteFailsOnMissingDescription(): void
     {
-        $generator = $this->createMock(PythonEmbeddingGenerator::class);
+        $generator = $this->createMock(PythonEmbeddingService::class);
         $generator->method('describeImage')->willReturn(null);
 
         $searchCommand = new class extends Command {


### PR DESCRIPTION
## Summary
- update MilvusVectorStoreService to rely on PythonEmbeddingService for dimension
- rename `PythonEmbeddingGenerator` to `PythonEmbeddingService` and add `getVectorDimension`
- adjust ProcessImageCommand and configuration to use the renamed service

## Testing
- `php bin/phpunit` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685e6f9ae0388331b2b5eb9efb8e74fe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The embedding service now automatically determines the vector dimension, improving flexibility and reducing manual configuration.

* **Refactor**
  * The embedding generator service has been renamed for clarity across the application.
  * Internal dependencies have been updated to use the new embedding service.

* **Bug Fixes**
  * Improved error handling and logging when retrieving the vector dimension from the embedding service.

* **Tests**
  * Updated tests to reflect the new embedding service naming and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->