### PR TITLE
Use new API search routes in webview

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,18 @@ The application exposes a small API for generating embeddings directly:
 - `POST /image-embedding` – upload an image file to receive a description and vector.
 - `GET /healthstatus` – simple health check of the embedding service.
 
+### Search API
+
+Product search can also be accessed via JSON endpoints which mirror the
+functionality of the web interface:
+
+- `POST /api/search/text` – send `{ "message": "smartphone" }` and receive search
+  results.
+- `POST /api/search/image` – upload an image file (field name `image`) to search
+  based on its description.
+- `POST /api/search/audio` – upload an audio file (field name `audio`) which is
+  transcribed and used as the search query.
+
 ## Customization
 
 ### Extending the Application

--- a/src/Controller/ApiSearchController.php
+++ b/src/Controller/ApiSearchController.php
@@ -18,6 +18,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\MapRequestPayload;
 use Symfony\Component\Routing\Attribute\Route;
+use OpenApi\Attributes as OA;
 
 class ApiSearchController extends AbstractController
 {
@@ -123,6 +124,23 @@ class ApiSearchController extends AbstractController
     }
 
     #[Route('/api/search/text', name: 'api_search_text', methods: ['POST'])]
+    #[OA\Post(
+        path: '/api/search/text',
+        summary: 'Search for products using a text query',
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(ref: '#/components/schemas/ChatRequestDto')
+        ),
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Search results and recommendation',
+                content: new OA\JsonContent(ref: '#/components/schemas/ChatResponseDto')
+            ),
+            new OA\Response(response: 400, description: 'Invalid request')
+        ],
+        tags: ['Search API']
+    )]
     public function searchText(#[MapRequestPayload] ChatRequestDto $chatRequest): JsonResponse
     {
         $query = $chatRequest->message;
@@ -137,6 +155,31 @@ class ApiSearchController extends AbstractController
     }
 
     #[Route('/api/search/image', name: 'api_search_image', methods: ['POST'])]
+    #[OA\Post(
+        path: '/api/search/image',
+        summary: 'Search using an uploaded image',
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\MediaType(
+                mediaType: 'multipart/form-data',
+                schema: new OA\Schema(
+                    type: 'object',
+                    properties: [
+                        new OA\Property(property: 'image', type: 'string', format: 'binary')
+                    ]
+                )
+            )
+        ),
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Search results and recommendation',
+                content: new OA\JsonContent(ref: '#/components/schemas/ChatResponseDto')
+            ),
+            new OA\Response(response: 400, description: 'Invalid request')
+        ],
+        tags: ['Search API']
+    )]
     public function searchImage(Request $request): JsonResponse
     {
         /** @var UploadedFile|null $file */
@@ -164,6 +207,32 @@ class ApiSearchController extends AbstractController
     }
 
     #[Route('/api/search/audio', name: 'api_search_audio', methods: ['POST'])]
+    #[OA\Post(
+        path: '/api/search/audio',
+        summary: 'Search using an uploaded audio file',
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\MediaType(
+                mediaType: 'multipart/form-data',
+                schema: new OA\Schema(
+                    type: 'object',
+                    properties: [
+                        new OA\Property(property: 'audio', type: 'string', format: 'binary')
+                    ]
+                )
+            )
+        ),
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Search results and recommendation',
+                content: new OA\JsonContent(ref: '#/components/schemas/ChatResponseDto')
+            ),
+            new OA\Response(response: 400, description: 'Invalid request'),
+            new OA\Response(response: 500, description: 'Transcription failed')
+        ],
+        tags: ['Search API']
+    )]
     public function searchAudio(Request $request): JsonResponse
     {
         /** @var UploadedFile|null $file */

--- a/src/Controller/ApiSearchController.php
+++ b/src/Controller/ApiSearchController.php
@@ -11,6 +11,7 @@ use App\Service\PromptServiceInterface;
 use App\Service\SearchServiceInterface;
 use App\Service\SpeechToTextServiceInterface;
 use App\Service\VectorStoreInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -26,6 +27,7 @@ class ApiSearchController extends AbstractController
     private SearchServiceInterface $searchService;
     private OpenAIEmbeddingService $embeddingService;
     private SpeechToTextServiceInterface $sttService;
+    private LoggerInterface $logger;
 
     public function __construct(
         EmbeddingGeneratorInterface $embeddingGenerator,
@@ -33,7 +35,8 @@ class ApiSearchController extends AbstractController
         SearchServiceInterface $searchService,
         PromptServiceInterface $promptService,
         OpenAIEmbeddingService $embeddingService,
-        SpeechToTextServiceInterface $sttService
+        SpeechToTextServiceInterface $sttService,
+        LoggerInterface $logger
     ) {
         $this->embeddingGenerator = $embeddingGenerator;
         $this->vectorStoreService = $vectorStoreService;
@@ -41,6 +44,7 @@ class ApiSearchController extends AbstractController
         $this->promptService = $promptService;
         $this->embeddingService = $embeddingService;
         $this->sttService = $sttService;
+        $this->logger = $logger;
     }
 
     /**
@@ -50,15 +54,30 @@ class ApiSearchController extends AbstractController
      */
     private function runSearch(array $vector, string $query): ChatResponseDto
     {
+        $this->logger->info('Running product search', [
+            'query' => $query,
+            'vector_length' => count($vector),
+        ]);
+
         $results = $this->vectorStoreService->searchSimilarProducts($vector, 3);
 
+        $this->logger->debug('Vector search results', [
+            'count' => count($results),
+        ]);
+
         if (empty($results)) {
+            $this->logger->info('No results from vector store', ['query' => $query]);
             $noResultsMessage = $this->promptService->getPrompt('product_finder', 'no_results_message');
             return new ChatResponseDto(true, $query, null, $noResultsMessage, []);
         }
 
         $filteredResults = array_filter($results, static fn($r) => isset($r['distance']) && $r['distance'] <= 0.5);
+
+        $this->logger->debug('Filtered results', [
+            'count' => count($filteredResults),
+        ]);
         if (empty($filteredResults)) {
+            $this->logger->info('No results after filtering', ['query' => $query]);
             $noResultsMessage = $this->promptService->getPrompt('product_finder', 'no_results_message');
             return new ChatResponseDto(true, $query, null, $noResultsMessage, []);
         }
@@ -88,7 +107,17 @@ class ApiSearchController extends AbstractController
         ];
         $recommendation = $this->searchService->generateChatCompletion($messages);
 
+        $this->logger->info('Generated recommendation', [
+            'query' => $query,
+            'product_count' => count($filteredResults),
+        ]);
+
         $productDtos = array_map(static fn($r) => ProductResponseDto::fromArray($r), $filteredResults);
+
+        $this->logger->info('Search finished', [
+            'query' => $query,
+            'returned_products' => count($productDtos),
+        ]);
 
         return new ChatResponseDto(true, $query, null, $recommendation, $productDtos);
     }
@@ -98,8 +127,10 @@ class ApiSearchController extends AbstractController
     {
         $query = $chatRequest->message;
         if ($query === '') {
+            $this->logger->warning('Text search with empty query');
             return new JsonResponse(['success' => false, 'message' => 'Message parameter is required'], 400);
         }
+        $this->logger->info('Text search request', ['query' => $query]);
         $vector = $this->embeddingGenerator->generateQueryEmbedding($query);
         $response = $this->runSearch($vector, $query);
         return $this->json($response);
@@ -111,15 +142,23 @@ class ApiSearchController extends AbstractController
         /** @var UploadedFile|null $file */
         $file = $request->files->get('image');
         if (!$file instanceof UploadedFile) {
+            $this->logger->warning('Image search without file');
             return new JsonResponse(['success' => false, 'message' => 'No image uploaded'], 400);
         }
+        $this->logger->info('Image search request', [
+            'filename' => $file->getClientOriginalName(),
+            'mime' => $file->getMimeType(),
+            'size' => $file->getSize(),
+        ]);
         $allowed = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
         if (!in_array($file->getMimeType(), $allowed, true)) {
+            $this->logger->warning('Invalid image type', ['mime' => $file->getMimeType()]);
             return new JsonResponse(['success' => false, 'message' => 'Invalid image type'], 400);
         }
         $result = $this->embeddingService->describeImageFile($file);
         $vector = $result['vector'] ?? [];
         $description = (string) ($result['description'] ?? '');
+        $this->logger->debug('Image description', ['description' => $description]);
         $response = $this->runSearch($vector, $description);
         return $this->json($response);
     }
@@ -130,18 +169,27 @@ class ApiSearchController extends AbstractController
         /** @var UploadedFile|null $file */
         $file = $request->files->get('audio');
         if (!$file instanceof UploadedFile) {
+            $this->logger->warning('Audio search without file');
             return new JsonResponse(['success' => false, 'message' => 'No audio uploaded'], 400);
         }
+        $this->logger->info('Audio search request', [
+            'filename' => $file->getClientOriginalName(),
+            'mime' => $file->getMimeType(),
+            'size' => $file->getSize(),
+        ]);
         $temp = tempnam(sys_get_temp_dir(), 'aud');
         if ($temp === false) {
+            $this->logger->error('Unable to create temp file for audio');
             return new JsonResponse(['success' => false, 'message' => 'Could not create temp file'], 500);
         }
         $file->move(dirname($temp), basename($temp));
         $text = $this->sttService->transcribe($temp);
         @unlink($temp);
         if ($text === null || $text === '') {
+            $this->logger->warning('Transcription failed');
             return new JsonResponse(['success' => false, 'message' => 'Transcription failed'], 500);
         }
+        $this->logger->debug('Transcribed audio', ['text' => $text]);
         $vector = $this->embeddingGenerator->generateQueryEmbedding($text);
         $response = $this->runSearch($vector, $text);
         return $this->json($response);

--- a/src/Controller/ApiSearchController.php
+++ b/src/Controller/ApiSearchController.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace App\Controller;
+
+use App\DTO\Request\ChatRequestDto;
+use App\DTO\Response\ChatResponseDto;
+use App\DTO\Response\ProductResponseDto;
+use App\Service\EmbeddingGeneratorInterface;
+use App\Service\OpenAIEmbeddingService;
+use App\Service\PromptServiceInterface;
+use App\Service\SearchServiceInterface;
+use App\Service\SpeechToTextServiceInterface;
+use App\Service\VectorStoreInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\MapRequestPayload;
+use Symfony\Component\Routing\Attribute\Route;
+
+class ApiSearchController extends AbstractController
+{
+    private EmbeddingGeneratorInterface $embeddingGenerator;
+    private VectorStoreInterface $vectorStoreService;
+    private PromptServiceInterface $promptService;
+    private SearchServiceInterface $searchService;
+    private OpenAIEmbeddingService $embeddingService;
+    private SpeechToTextServiceInterface $sttService;
+
+    public function __construct(
+        EmbeddingGeneratorInterface $embeddingGenerator,
+        VectorStoreInterface $vectorStoreService,
+        SearchServiceInterface $searchService,
+        PromptServiceInterface $promptService,
+        OpenAIEmbeddingService $embeddingService,
+        SpeechToTextServiceInterface $sttService
+    ) {
+        $this->embeddingGenerator = $embeddingGenerator;
+        $this->vectorStoreService = $vectorStoreService;
+        $this->searchService = $searchService;
+        $this->promptService = $promptService;
+        $this->embeddingService = $embeddingService;
+        $this->sttService = $sttService;
+    }
+
+    /**
+     * Execute search based on an embedding vector and query string.
+     *
+     * @param array<int, float> $vector
+     */
+    private function runSearch(array $vector, string $query): ChatResponseDto
+    {
+        $results = $this->vectorStoreService->searchSimilarProducts($vector, 3);
+
+        if (empty($results)) {
+            $noResultsMessage = $this->promptService->getPrompt('product_finder', 'no_results_message');
+            return new ChatResponseDto(true, $query, null, $noResultsMessage, []);
+        }
+
+        $filteredResults = array_filter($results, static fn($r) => isset($r['distance']) && $r['distance'] <= 0.5);
+        if (empty($filteredResults)) {
+            $noResultsMessage = $this->promptService->getPrompt('product_finder', 'no_results_message');
+            return new ChatResponseDto(true, $query, null, $noResultsMessage, []);
+        }
+
+        $systemPromptContent = $this->promptService->getPrompt('product_finder', 'system_prompt');
+        $systemPrompt = [
+            'role' => 'system',
+            'content' => $systemPromptContent,
+        ];
+
+        $productsList = '';
+        foreach ($filteredResults as $index => $result) {
+            $productsList .= ($index + 1) . '. ' . ($result['title'] ?? 'Unknown product') . ' (Similarity: ' . (($result['distance'] ?? 0)) . ")\n";
+        }
+
+        $userMessageContent = $this->promptService->getPrompt('product_finder', 'user_message_template', [
+            'query' => $query,
+            'products_list' => $productsList,
+        ]);
+
+        $messages = [
+            $systemPrompt,
+            [
+                'role' => 'user',
+                'content' => $userMessageContent,
+            ],
+        ];
+        $recommendation = $this->searchService->generateChatCompletion($messages);
+
+        $productDtos = array_map(static fn($r) => ProductResponseDto::fromArray($r), $filteredResults);
+
+        return new ChatResponseDto(true, $query, null, $recommendation, $productDtos);
+    }
+
+    #[Route('/api/search/text', name: 'api_search_text', methods: ['POST'])]
+    public function searchText(#[MapRequestPayload] ChatRequestDto $chatRequest): JsonResponse
+    {
+        $query = $chatRequest->message;
+        if ($query === '') {
+            return new JsonResponse(['success' => false, 'message' => 'Message parameter is required'], 400);
+        }
+        $vector = $this->embeddingGenerator->generateQueryEmbedding($query);
+        $response = $this->runSearch($vector, $query);
+        return $this->json($response);
+    }
+
+    #[Route('/api/search/image', name: 'api_search_image', methods: ['POST'])]
+    public function searchImage(Request $request): JsonResponse
+    {
+        /** @var UploadedFile|null $file */
+        $file = $request->files->get('image');
+        if (!$file instanceof UploadedFile) {
+            return new JsonResponse(['success' => false, 'message' => 'No image uploaded'], 400);
+        }
+        $allowed = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
+        if (!in_array($file->getMimeType(), $allowed, true)) {
+            return new JsonResponse(['success' => false, 'message' => 'Invalid image type'], 400);
+        }
+        $result = $this->embeddingService->describeImageFile($file);
+        $vector = $result['vector'] ?? [];
+        $description = (string) ($result['description'] ?? '');
+        $response = $this->runSearch($vector, $description);
+        return $this->json($response);
+    }
+
+    #[Route('/api/search/audio', name: 'api_search_audio', methods: ['POST'])]
+    public function searchAudio(Request $request): JsonResponse
+    {
+        /** @var UploadedFile|null $file */
+        $file = $request->files->get('audio');
+        if (!$file instanceof UploadedFile) {
+            return new JsonResponse(['success' => false, 'message' => 'No audio uploaded'], 400);
+        }
+        $temp = tempnam(sys_get_temp_dir(), 'aud');
+        if ($temp === false) {
+            return new JsonResponse(['success' => false, 'message' => 'Could not create temp file'], 500);
+        }
+        $file->move(dirname($temp), basename($temp));
+        $text = $this->sttService->transcribe($temp);
+        @unlink($temp);
+        if ($text === null || $text === '') {
+            return new JsonResponse(['success' => false, 'message' => 'Transcription failed'], 500);
+        }
+        $vector = $this->embeddingGenerator->generateQueryEmbedding($text);
+        $response = $this->runSearch($vector, $text);
+        return $this->json($response);
+    }
+}

--- a/src/Controller/ApiSearchController.php
+++ b/src/Controller/ApiSearchController.php
@@ -72,7 +72,7 @@ class ApiSearchController extends AbstractController
             return new ChatResponseDto(true, $query, null, $noResultsMessage, []);
         }
 
-        $filteredResults = array_filter($results, static fn($r) => isset($r['distance']) && $r['distance'] <= 0.5);
+        $filteredResults = array_filter($results, static fn($r) => isset($r['distance']) && $r['distance'] >= 0.5);
 
         $this->logger->debug('Filtered results', [
             'count' => count($filteredResults),

--- a/src/DTO/Request/ChatRequestDto.php
+++ b/src/DTO/Request/ChatRequestDto.php
@@ -2,8 +2,17 @@
 
 namespace App\DTO\Request;
 
+use OpenApi\Attributes as OA;
+
 use Symfony\Component\Validator\Constraints as Assert;
 
+#[OA\Schema(
+    schema: 'ChatRequestDto',
+    required: ['message'],
+    properties: [
+        new OA\Property(property: 'message', type: 'string', example: 'smartphone')
+    ]
+)]
 readonly class ChatRequestDto
 {
     #[Assert\NotBlank(message: "Message parameter is required")]

--- a/src/DTO/Response/ChatResponseDto.php
+++ b/src/DTO/Response/ChatResponseDto.php
@@ -2,6 +2,22 @@
 
 namespace App\DTO\Response;
 
+use OpenApi\Attributes as OA;
+
+#[OA\Schema(
+    schema: 'ChatResponseDto',
+    properties: [
+        new OA\Property(property: 'success', type: 'boolean'),
+        new OA\Property(property: 'query', type: 'string', nullable: true),
+        new OA\Property(property: 'message', type: 'string', nullable: true),
+        new OA\Property(property: 'response', type: 'string', nullable: true),
+        new OA\Property(
+            property: 'products',
+            type: 'array',
+            items: new OA\Items(ref: '#/components/schemas/ProductResponseDto')
+        )
+    ]
+)]
 readonly class ChatResponseDto implements \JsonSerializable
 {
     public bool $success;

--- a/src/DTO/Response/ProductResponseDto.php
+++ b/src/DTO/Response/ProductResponseDto.php
@@ -2,6 +2,16 @@
 
 namespace App\DTO\Response;
 
+use OpenApi\Attributes as OA;
+
+#[OA\Schema(
+    schema: 'ProductResponseDto',
+    properties: [
+        new OA\Property(property: 'id', type: 'string', nullable: true),
+        new OA\Property(property: 'title', type: 'string', nullable: true),
+        new OA\Property(property: 'distance', type: 'number', format: 'float', nullable: true)
+    ]
+)]
 class ProductResponseDto implements \JsonSerializable
 {
     public readonly ?string $id;

--- a/templates/home/index.html.twig
+++ b/templates/home/index.html.twig
@@ -139,19 +139,25 @@ sequenceDiagram
         function searchProducts(query) {
             addMessage('Suche nach passenden Produkten...', false);
 
-            fetch('/search', {
+            fetch('/api/search/text', {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
                 },
-                body: JSON.stringify({ query: query })
+                body: JSON.stringify({ message: query })
             })
             .then(response => response.json())
             .then(data => {
                 if (data.success) {
-                    addMessage(`<pre>${data.output}</pre>`, false);
+                    if (data.response) {
+                        addMessage(data.response, false);
+                    }
+                    if (Array.isArray(data.products)) {
+                        displayProducts(data.products);
+                    }
                 } else {
-                    addMessage('Es ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut.', false);
+                    const msg = data.message || 'Es ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut.';
+                    addMessage(msg, false);
                 }
             })
             .catch(error => {
@@ -170,16 +176,22 @@ sequenceDiagram
             const formData = new FormData();
             formData.append('image', file, file.name || 'upload.png');
 
-            fetch('/search/image', {
+            fetch('/api/search/image', {
                 method: 'POST',
                 body: formData
             })
             .then(response => response.json())
             .then(data => {
                 if (data.success) {
-                    addMessage(`<pre>${data.output}</pre>`, false);
+                    if (data.response) {
+                        addMessage(data.response, false);
+                    }
+                    if (Array.isArray(data.products)) {
+                        displayProducts(data.products);
+                    }
                 } else {
-                    addMessage('Es ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut.', false);
+                    const msg = data.message || 'Es ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut.';
+                    addMessage(msg, false);
                 }
             })
             .catch(error => {
@@ -197,16 +209,22 @@ sequenceDiagram
             const formData = new FormData();
             formData.append('audio', blob, 'recording.webm');
 
-            fetch('/search/audio', {
+            fetch('/api/search/audio', {
                 method: 'POST',
                 body: formData
             })
             .then(response => response.json())
             .then(data => {
                 if (data.success) {
-                    addMessage(`<pre>${data.output}</pre>`, false);
+                    if (data.response) {
+                        addMessage(data.response, false);
+                    }
+                    if (Array.isArray(data.products)) {
+                        displayProducts(data.products);
+                    }
                 } else {
-                    addMessage('Es ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut.', false);
+                    const msg = data.message || 'Es ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut.';
+                    addMessage(msg, false);
                 }
             })
             .catch(error => {
@@ -223,7 +241,7 @@ sequenceDiagram
                 productCard.className = 'col-md-6 mb-4';
                 
                 const productName = product.title || 'Unbekanntes Produkt';
-                const productId = product.primary_key || 'N/A';
+                const productId = product.id || 'N/A';
                 const score = product.distance ? (product.distance * 100).toFixed(1) + '%' : 'N/A';
                 
                 productCard.innerHTML = `


### PR DESCRIPTION
## Summary
- update web interface JavaScript to call `/api/search/*` routes
- parse JSON responses and display products

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6866710122008331be75db9eeee0a284

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced three new API endpoints for product search: text, image, and audio, allowing users to search products using different input types.
  * Enhanced the web interface to display search results with improved response formatting and clearer product information.

* **Documentation**
  * Updated the README with installation instructions for API documentation and detailed descriptions of the new search API endpoints.
  * Added API documentation metadata for request and response formats, enabling interactive exploration via Swagger UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->