### PR TITLE
Add endpoint for importing single product via JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,32 @@ ddev php bin/console app:import-products src/DataFixtures/xml/sample_products.xm
 
 The import process vectorizes each product as a single chunk for semantic search.
 
+### Importing a Single Product via API
+
+A single product can also be submitted as JSON and will be vectorized in the same way. Send a `POST` request to `/api/products` with the product data:
+
+```json
+{
+  "id": 6,
+  "title": "Google Pixel 8 Pro",
+  "sku": "GOOPIX8P-128-BLU",
+  "description": "...",
+  "brand": "Google",
+  "category": "Smartphones",
+  "price": 1099.00,
+  "image_url": "https://example.com/images/pixel-8-pro.jpg",
+  "rating": 4.7,
+  "stock": 28,
+  "specifications": {
+    "display": "6,7 Zoll LTPO OLED, 2992 x 1344 Pixel",
+    "processor": "Google Tensor G3"
+  },
+  "features": ["Face Unlock", "Wireless Charging"]
+}
+```
+
+The endpoint creates one chunk for the product, vectorizes it and stores it in the database. It responds with `200 OK` on success or an error message if something goes wrong.
+
 ### Testing Search
 
 Try the natural language search:

--- a/src/Controller/ProductImportController.php
+++ b/src/Controller/ProductImportController.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Controller;
+
+use App\Service\EmbeddingGeneratorInterface;
+use App\Service\JsonImportService;
+use App\Service\VectorStoreInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Attribute\Route;
+
+/**
+ * API endpoint for importing a single product as JSON.
+ */
+class ProductImportController extends AbstractController
+{
+    private EmbeddingGeneratorInterface $embeddingGenerator;
+    private VectorStoreInterface $vectorStoreService;
+    private JsonImportService $importService;
+
+    public function __construct(
+        EmbeddingGeneratorInterface $embeddingGenerator,
+        VectorStoreInterface $vectorStoreService,
+        JsonImportService $importService
+    ) {
+        $this->embeddingGenerator = $embeddingGenerator;
+        $this->vectorStoreService = $vectorStoreService;
+        $this->importService = $importService;
+    }
+
+    #[Route('/api/products', name: 'api_products_import', methods: ['POST'])]
+    public function importProduct(Request $request): JsonResponse
+    {
+        $payload = json_decode($request->getContent(), true);
+        if (!is_array($payload) || json_last_error() !== JSON_ERROR_NONE) {
+            return new JsonResponse(['message' => 'Invalid JSON payload'], 400);
+        }
+
+        try {
+            $product = $this->importService->importFromArray($payload);
+
+            // Ensure the collection exists
+            $this->vectorStoreService->initializeCollection();
+
+            $chunks = $this->embeddingGenerator->generateProductEmbeddings($product);
+            $this->vectorStoreService->insertProductChunks($product, $chunks);
+
+            return new JsonResponse(['success' => true]);
+        } catch (\RuntimeException $e) {
+            return new JsonResponse(['message' => $e->getMessage()], 400);
+        } catch (\Throwable $e) {
+            return new JsonResponse(['message' => $e->getMessage()], 500);
+        }
+    }
+}

--- a/src/Serializer/ProductJsonSerializer.php
+++ b/src/Serializer/ProductJsonSerializer.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Serializer;
+
+use App\Entity\Product;
+
+/**
+ * Serializer for converting JSON product data to Product objects.
+ */
+class ProductJsonSerializer
+{
+    /**
+     * Map of JSON keys to property types and setter methods.
+     *
+     * @var array<string, array{type: string, method: string}>
+     */
+    private const PROPERTY_MAPPING = [
+        'id' => ['type' => 'int', 'method' => 'setId'],
+        'title' => ['type' => 'string', 'method' => 'setName'],
+        'name' => ['type' => 'string', 'method' => 'setName'],
+        'sku' => ['type' => 'string', 'method' => 'setSku'],
+        'description' => ['type' => 'string', 'method' => 'setDescription'],
+        'brand' => ['type' => 'string', 'method' => 'setBrand'],
+        'category' => ['type' => 'string', 'method' => 'setCategory'],
+        'price' => ['type' => 'float', 'method' => 'setPrice'],
+        'image_url' => ['type' => 'string', 'method' => 'setImageUrl'],
+        'rating' => ['type' => 'float', 'method' => 'setRating'],
+        'stock' => ['type' => 'int', 'method' => 'setStock'],
+    ];
+
+    /**
+     * Create a Product object from an associative array.
+     *
+     * @param array<string, mixed> $data
+     */
+    public function deserialize(array $data): Product
+    {
+        $product = new Product();
+
+        foreach (self::PROPERTY_MAPPING as $key => $config) {
+            if (array_key_exists($key, $data)) {
+                $value = $data[$key];
+                switch ($config['type']) {
+                    case 'int':
+                        $value = (int) $value;
+                        break;
+                    case 'float':
+                        $value = (float) $value;
+                        break;
+                    case 'string':
+                    default:
+                        $value = (string) $value;
+                        break;
+                }
+                $method = $config['method'];
+                $product->$method($value);
+            }
+        }
+
+        $specifications = [];
+        if (isset($data['specifications']) && is_array($data['specifications'])) {
+            foreach ($data['specifications'] as $name => $value) {
+                $specifications[(string) $name] = (string) $value;
+            }
+        }
+        $product->setSpecifications($specifications);
+
+        $features = [];
+        if (isset($data['features']) && is_array($data['features'])) {
+            foreach ($data['features'] as $feature) {
+                $features[] = (string) $feature;
+            }
+        }
+        $product->setFeatures($features);
+
+        return $product;
+    }
+}

--- a/src/Serializer/ProductJsonSerializer.php
+++ b/src/Serializer/ProductJsonSerializer.php
@@ -40,6 +40,13 @@ class ProductJsonSerializer
         foreach (self::PROPERTY_MAPPING as $key => $config) {
             if (array_key_exists($key, $data)) {
                 $value = $data[$key];
+                $method = $config['method'];
+
+                if ($value === null) {
+                    $product->$method(null);
+                    continue;
+                }
+
                 switch ($config['type']) {
                     case 'int':
                         $value = (int) $value;
@@ -52,13 +59,18 @@ class ProductJsonSerializer
                         $value = (string) $value;
                         break;
                 }
-                $method = $config['method'];
+
                 $product->$method($value);
             }
         }
 
-        $specifications = [];
-        if (isset($data['specifications']) && is_array($data['specifications'])) {
+        $specifications = null;
+        if (
+            isset($data['specifications']) &&
+            is_array($data['specifications']) &&
+            !array_is_list($data['specifications'])
+        ) {
+            $specifications = [];
             foreach ($data['specifications'] as $name => $value) {
                 $specifications[(string) $name] = (string) $value;
             }

--- a/src/Service/JsonImportService.php
+++ b/src/Service/JsonImportService.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Service;
+
+use App\Entity\Product;
+use App\Serializer\ProductJsonSerializer;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+/**
+ * Service to import and validate a product from JSON data.
+ */
+class JsonImportService
+{
+    private ValidatorInterface $validator;
+    private ProductJsonSerializer $serializer;
+
+    public function __construct(
+        ValidatorInterface $validator,
+        ProductJsonSerializer $serializer
+    ) {
+        $this->validator = $validator;
+        $this->serializer = $serializer;
+    }
+
+    /**
+     * Import product from JSON string.
+     */
+    public function importFromString(string $jsonContent): Product
+    {
+        $data = json_decode($jsonContent, true);
+        if (!is_array($data) || json_last_error() !== JSON_ERROR_NONE) {
+            throw new \RuntimeException('Invalid JSON format');
+        }
+        return $this->importFromArray($data);
+    }
+
+    /**
+     * Import product from associative array.
+     *
+     * @param array<string, mixed> $data
+     */
+    public function importFromArray(array $data): Product
+    {
+        $product = $this->serializer->deserialize($data);
+        $this->validateProduct($product);
+        return $product;
+    }
+
+    private function validateProduct(Product $product): void
+    {
+        $violations = $this->validator->validate($product);
+        if (count($violations) > 0) {
+            throw new \RuntimeException($this->formatViolations($violations));
+        }
+    }
+
+    private function formatViolations(ConstraintViolationListInterface $violations): string
+    {
+        $errors = [];
+        foreach ($violations as $violation) {
+            $errors[] = sprintf('%s: %s', $violation->getPropertyPath(), $violation->getMessage());
+        }
+
+        return 'Product validation failed: ' . implode(', ', $errors);
+    }
+}

--- a/src/Service/JsonImportService.php
+++ b/src/Service/JsonImportService.php
@@ -49,6 +49,18 @@ class JsonImportService
 
     private function validateProduct(Product $product): void
     {
+        $missing = [];
+        if ($product->getId() === null) {
+            $missing[] = 'id';
+        }
+        $name = $product->getName();
+        if ($name === null || $name === '') {
+            $missing[] = 'name';
+        }
+        if ($missing !== []) {
+            throw new \RuntimeException('Required fields missing: ' . implode(', ', $missing));
+        }
+
         $violations = $this->validator->validate($product);
         if (count($violations) > 0) {
             throw new \RuntimeException($this->formatViolations($violations));

--- a/src/Service/OpenAIEmbeddingService.php
+++ b/src/Service/OpenAIEmbeddingService.php
@@ -150,11 +150,18 @@ class OpenAIEmbeddingService implements EmbeddingGeneratorInterface
         if ($product->getDescription()) {
             $parts[] = $product->getDescription();
         }
-        foreach ($product->getSpecifications() as $name => $value) {
-            $parts[] = sprintf('%s: %s', $name, $value);
+        $specifications = $product->getSpecifications();
+        if (is_array($specifications)) {
+            foreach ($specifications as $name => $value) {
+                $parts[] = sprintf('%s: %s', $name, $value);
+            }
         }
-        foreach ($product->getFeatures() as $feature) {
-            $parts[] = $feature;
+
+        $features = $product->getFeatures();
+        if (is_array($features)) {
+            foreach ($features as $feature) {
+                $parts[] = $feature;
+            }
         }
 
         $text = trim(implode("\n", $parts));


### PR DESCRIPTION
## Summary
- allow POST /api/products to accept a single product in JSON
- add `ProductJsonSerializer` and `JsonImportService`
- document JSON import endpoint

## Testing
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866a22a6a8083318a8785ec8473c2cd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new API endpoint to import a single product via JSON POST requests.
  * Enabled product import through JSON submissions alongside existing XML import methods.
* **Documentation**
  * Updated README with detailed instructions and examples for using the new JSON product import API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->