### PR TITLE
Require API key for all routes

### DIFF
--- a/.env
+++ b/.env
@@ -19,6 +19,8 @@ APP_ENV=dev
 APP_SECRET=c79f2b33be8ec7022714dd82f2174373
 ###< symfony/framework-bundle ###
 
+APP_API_KEY=changeme
+
 OPENAI_API_KEY=YOUR_OPENAI_API_KEY_PLACEHOLDER
 
 OPENAI_CHAT_MODEL=gpt-3.5-turbo

--- a/.env.dist
+++ b/.env.dist
@@ -19,6 +19,9 @@ APP_ENV=dev
 APP_SECRET=YOUR_APP_SECRET
 ###< symfony/framework-bundle ###
 
+# API key required for all endpoints
+APP_API_KEY=changeme
+
 OPENAI_API_KEY=YOUR_OPENAI_API_KEY_PLACEHOLDER
 OPENAI_MODEL=text-embedding-ada-002
 OPENAI_MODEL_IMAGE=gpt-4o

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ For detailed architecture diagrams, see the [Architecture Documentation](https:/
   OPENAI_MODEL_IMAGE=gpt-4o
   OPENAI_CHAT_MODEL=gpt-3.5-turbo
   DEBUG_VECTORS=false
+  APP_API_KEY=choose_a_secret_key
   MILVUS_API_KEY=your_milvus_api_key
    MILVUS_HOST=your_milvus_endpoint
    MILVUS_PORT=443
@@ -157,6 +158,10 @@ ddev php bin/console app:process-image path/to/image.jpg
 ### Web Interface
 
 Access the chat interface at `https://symfony-product-finder.ddev.site/` to search for products using natural language.
+
+### API Authentication
+
+All API endpoints require an `X-API-Key` header containing the value of `APP_API_KEY` defined in your environment. Requests without a valid key will be rejected with `401 Unauthorized`.
 
 ### Embedding API
 

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -4,6 +4,7 @@
 # Put parameters here that don't need to change on each machine where the app is deployed
 # https://symfony.com/doc/current/best_practices.html#use-parameters-for-application-configuration
 parameters:
+    app.api_key: '%env(APP_API_KEY)%'
 
 services:
     # default configuration for services in *this* file
@@ -21,6 +22,10 @@ services:
             - '../src/Kernel.php'
 
     App\Factory\MilvusClientFactory: ~
+
+    App\EventSubscriber\ApiKeySubscriber:
+        arguments:
+            $apiKey: '%app.api_key%'
 
     Milvus\Client:
         factory: ['@App\Factory\MilvusClientFactory', 'create']

--- a/src/EventSubscriber/ApiKeySubscriber.php
+++ b/src/EventSubscriber/ApiKeySubscriber.php
@@ -30,9 +30,9 @@ class ApiKeySubscriber implements EventSubscriberInterface
         }
 
         $request = $event->getRequest();
-        $providedKey = $request->headers->get('X-API-Key') ?? $request->query->get('api_key');
+        $providedKey = $request->headers->get('X-API-Key');
 
-        if ($this->apiKey === '' || $providedKey !== $this->apiKey) {
+        if ($providedKey !== $this->apiKey) {
             $event->setResponse(new JsonResponse(['message' => 'Invalid API key'], 401));
         }
     }

--- a/src/EventSubscriber/ApiKeySubscriber.php
+++ b/src/EventSubscriber/ApiKeySubscriber.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\EventSubscriber;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+class ApiKeySubscriber implements EventSubscriberInterface
+{
+    private string $apiKey;
+
+    public function __construct(string $apiKey)
+    {
+        $this->apiKey = $apiKey;
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::REQUEST => ['onKernelRequest', 255],
+        ];
+    }
+
+    public function onKernelRequest(RequestEvent $event): void
+    {
+        if (!$event->isMainRequest()) {
+            return;
+        }
+
+        $request = $event->getRequest();
+        $providedKey = $request->headers->get('X-API-Key') ?? $request->query->get('api_key');
+
+        if ($this->apiKey === '' || $providedKey !== $this->apiKey) {
+            $event->setResponse(new JsonResponse(['message' => 'Invalid API key'], 401));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- enforce global API key via `ApiKeySubscriber`
- wire API key parameter in service config
- document new `APP_API_KEY` variable and header usage
- add default key values in `.env` files

## Testing
- `bin/phpunit --version` *(fails: `/usr/bin/env: 'php': No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_686f8c5302588331872e39f567c7959d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced API authentication for all endpoints using an API key.
  * Unauthorized requests without a valid API key now receive a 401 Unauthorized response.

* **Documentation**
  * Updated environment variable examples and added instructions for API authentication in the documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->