### PR TITLE
Handle API key for web interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Access the chat interface at `https://symfony-product-finder.ddev.site/` to sear
 ### API Authentication
 
 All API endpoints require an `X-API-Key` header containing the value of `APP_API_KEY` defined in your environment. Requests without a valid key will be rejected with `401 Unauthorized`.
+When you open the web interface at `/`, the application issues the API key as an HTTP-only cookie so that subsequent AJAX requests can access the protected API without exposing the key in the browser.
 
 ### Embedding API
 

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -26,6 +26,16 @@ services:
     App\EventSubscriber\ApiKeySubscriber:
         arguments:
             $apiKey: '%app.api_key%'
+            $cookieName: 'api_key'
+            $excludedPaths:
+                - '/'
+                - '/search'
+                - '/search/image'
+                - '/search/audio'
+
+    App\Controller\WebInterfaceController:
+        arguments:
+            $apiKey: '%app.api_key%'
 
     Milvus\Client:
         factory: ['@App\Factory\MilvusClientFactory', 'create']

--- a/src/Controller/WebInterfaceController.php
+++ b/src/Controller/WebInterfaceController.php
@@ -6,6 +6,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Input\ArrayInput;
@@ -25,15 +26,21 @@ class WebInterfaceController extends AbstractController
     private const MAX_AUDIO_SIZE = 5242880; // 5 MB
 
     private LoggerInterface $logger;
+    private string $apiKey;
 
-    public function __construct(LoggerInterface $logger)
+    public function __construct(LoggerInterface $logger, string $apiKey)
     {
         $this->logger = $logger;
+        $this->apiKey = $apiKey;
     }
     #[Route('/', name: 'app_home')]
     public function index(): Response
     {
-        return $this->render('home/index.html.twig');
+        $response = $this->render('home/index.html.twig');
+        $cookie = Cookie::create('api_key', $this->apiKey)
+            ->withHttpOnly(true);
+        $response->headers->setCookie($cookie);
+        return $response;
     }
 
     #[Route('/search', name: 'app_web_search', methods: ['POST'])]

--- a/src/EventSubscriber/ApiKeySubscriber.php
+++ b/src/EventSubscriber/ApiKeySubscriber.php
@@ -10,10 +10,20 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 class ApiKeySubscriber implements EventSubscriberInterface
 {
     private string $apiKey;
+    private string $cookieName;
+    /**
+     * @var array<string>
+     */
+    private array $excludedPaths;
 
-    public function __construct(string $apiKey)
+    /**
+     * @param array<string> $excludedPaths
+     */
+    public function __construct(string $apiKey, string $cookieName = 'api_key', array $excludedPaths = ['/'])
     {
         $this->apiKey = $apiKey;
+        $this->cookieName = $cookieName;
+        $this->excludedPaths = $excludedPaths;
     }
 
     public static function getSubscribedEvents(): array
@@ -30,7 +40,15 @@ class ApiKeySubscriber implements EventSubscriberInterface
         }
 
         $request = $event->getRequest();
+
+        if (in_array($request->getPathInfo(), $this->excludedPaths, true)) {
+            return;
+        }
+
         $providedKey = $request->headers->get('X-API-Key');
+        if ($providedKey === null) {
+            $providedKey = $request->cookies->get($this->cookieName);
+        }
 
         if ($providedKey !== $this->apiKey) {
             $event->setResponse(new JsonResponse(['message' => 'Invalid API key'], 401));


### PR DESCRIPTION
## Summary
- allow API key in an HttpOnly cookie
- skip API key check for web routes
- inject the API key cookie on the root page
- document web cookie use in README

## Testing
- `php -l src/EventSubscriber/ApiKeySubscriber.php`
- `php -l src/Controller/WebInterfaceController.php`
- `bin/phpunit` *(fails: Unable to find the `simple-phpunit.php` script)*


------
https://chatgpt.com/codex/tasks/task_e_6870de161ba883318ee60333dc1856e2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * When accessing the web interface at the root path, the application now stores the API key in the server session, enabling seamless authentication for subsequent AJAX requests without exposing the key in the browser.
* **Documentation**
  * Clarified in the README how API authentication works via server session storage when using the web interface.
* **Bug Fixes**
  * Improved API key validation to support authentication via both HTTP headers and session storage, with certain paths excluded from validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->