### PR TITLE
Fix audio temp file extension and logging

### DIFF
--- a/src/Service/OpenAISpeechToTextService.php
+++ b/src/Service/OpenAISpeechToTextService.php
@@ -34,6 +34,10 @@ class OpenAISpeechToTextService implements SpeechToTextServiceInterface
                 'path' => $audioPath,
                 'size' => filesize($audioPath),
             ]);
+            $this->logger->debug('Audio file details', [
+                'mime' => mime_content_type($audioPath) ?: 'unknown',
+                'extension' => pathinfo($audioPath, PATHINFO_EXTENSION),
+            ]);
 
             $response = $this->client->audio()->transcribe([
                 'model' => $this->model,
@@ -52,8 +56,10 @@ class OpenAISpeechToTextService implements SpeechToTextServiceInterface
             return null;
         } catch (\Throwable $e) {
             $this->logger->error('Error during OpenAI Whisper transcription', [
-                'exception' => $e,
+                'message' => $e->getMessage(),
+                'path' => $audioPath,
             ]);
+            $this->logger->debug('Whisper exception', ['exception' => $e]);
             return null;
         }
     }


### PR DESCRIPTION
## Summary
- keep file extension when storing uploaded audio in a temp file
- add debug logging for the audio temp path
- log more details in the speech-to-text service

## Testing
- `php -l src/Service/OpenAISpeechToTextService.php`
- `php -l src/Controller/ApiSearchController.php`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6874c69abae48331a83f199a7bc2cfe4