### PR TITLE
ref: using external product ids

### DIFF
--- a/src/DTO/Response/ProductResponseDto.php
+++ b/src/DTO/Response/ProductResponseDto.php
@@ -43,7 +43,7 @@ class ProductResponseDto implements \JsonSerializable
     public static function fromArray(array $data): self
     {
         return new self(
-            $data['id'] ?? null,
+            $data['product_id'] ?? null,
             $data['title'] ?? null,
             $data['distance'] ?? null
         );

--- a/src/Service/MilvusVectorStoreService.php
+++ b/src/Service/MilvusVectorStoreService.php
@@ -353,7 +353,7 @@ class MilvusVectorStoreService implements VectorStoreInterface
                 collectionName: $this->collectionName, // Corrected collection name
                 vector: $queryEmbedding,
                 limit: $limit,
-                outputFields: ["id", "title"],
+                outputFields: ["product_id", "title"],
                 dbName: $this->collectionName
             );
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected product identifier handling to use "product_id" instead of "id" in product data and search results, ensuring consistent and accurate product identification throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->