### PR TITLE
Enable search history in AI product finder

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -95,3 +95,5 @@ services:
     App\Command\ProcessAudioCommand:
         arguments:
             $sttService: '@App\Service\OpenAISpeechToTextService'
+
+    App\Service\SearchHistoryService: ~

--- a/src/DTO/Request/ChatRequestDto.php
+++ b/src/DTO/Request/ChatRequestDto.php
@@ -10,7 +10,8 @@ use Symfony\Component\Validator\Constraints as Assert;
     schema: 'ChatRequestDto',
     required: ['message'],
     properties: [
-        new OA\Property(property: 'message', type: 'string', example: 'smartphone')
+        new OA\Property(property: 'message', type: 'string', example: 'smartphone'),
+        new OA\Property(property: 'use_history', type: 'boolean', example: false)
     ]
 )]
 readonly class ChatRequestDto
@@ -19,14 +20,18 @@ readonly class ChatRequestDto
     #[Assert\Type("string")]
     public string $message;
 
+    #[Assert\Type("bool")]
+    public bool $use_history;
+
     /****
      * Initializes a new ChatRequestDto with the provided message.
      *
      * @param string $message The chat message content. Defaults to an empty string.
      */
-    public function __construct(string $message = '')
+    public function __construct(string $message = '', bool $use_history = false)
     {
         $this->message = $message;
+        $this->use_history = $use_history;
     }
 
 }

--- a/src/Service/SearchHistoryService.php
+++ b/src/Service/SearchHistoryService.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Service;
+
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+
+/**
+ * Simple service to store and retrieve search queries in the user's session.
+ */
+class SearchHistoryService
+{
+    private SessionInterface $session;
+    private int $maxEntries;
+
+    public function __construct(SessionInterface $session, int $maxEntries = 5)
+    {
+        $this->session = $session;
+        $this->maxEntries = $maxEntries;
+    }
+
+    /**
+     * Add a query to the history.
+     */
+    public function addQuery(string $query): void
+    {
+        $history = $this->session->get('search_history', []);
+        $history[] = $query;
+        if (count($history) > $this->maxEntries) {
+            $history = array_slice($history, -$this->maxEntries);
+        }
+        $this->session->set('search_history', $history);
+    }
+
+    /**
+     * Retrieve all stored queries.
+     *
+     * @return string[]
+     */
+    public function getHistory(): array
+    {
+        return $this->session->get('search_history', []);
+    }
+
+    /**
+     * Remove all stored queries.
+     */
+    public function clear(): void
+    {
+        $this->session->remove('search_history');
+    }
+}
+

--- a/tests/SearchHistoryServiceTest.php
+++ b/tests/SearchHistoryServiceTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Tests;
+
+use App\Service\SearchHistoryService;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+
+class SearchHistoryServiceTest extends TestCase
+{
+    public function testHistoryIsLimitedAndStored(): void
+    {
+        $session = $this->createMock(SessionInterface::class);
+        $history = [];
+        $session->method('get')->willReturnCallback(fn($key, $default) => $history);
+        $session->expects($this->exactly(5))->method('set')->willReturnCallback(function($key, $val) use (&$history) { $history = $val; });
+        $service = new SearchHistoryService($session, 3);
+        $service->addQuery('a');
+        $service->addQuery('b');
+        $service->addQuery('c');
+        $service->addQuery('d');
+        $this->assertCount(3, $service->getHistory());
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `use_history` flag to `ChatRequestDto`
- store user queries in new `SearchHistoryService`
- combine query history when enabled in `ApiSearchController` and `ProductFinderController`
- wire new service via DI
- cover new history service with basic unit test

## Testing
- `php -l src/Service/SearchHistoryService.php`
- `php -l tests/SearchHistoryServiceTest.php`
- `php -l src/DTO/Request/ChatRequestDto.php`
- `php -l src/Controller/ProductFinderController.php`
- `php -l src/Controller/ApiSearchController.php`
- ❌ `vendor/bin/phpunit` *(failed: Could not open input file)*

------
https://chatgpt.com/codex/tasks/task_e_6880c028aeb48331aa885760df18a989

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multimodal search: search by text, image or audio (upload or camera capture) with optional history-aware embeddings.
  * Web UI refreshed (English), camera capture and improved upload flows for images/audio.
  * API endpoints for product import, text/image/audio search and embedding utilities; Postman collection and API docs added.
  * API key protection added for requests.

* **Documentation**
  * README rewritten in English; new API docs and examples.

* **Tests**
  * Added tests for search history, product import and image/audio processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->