### PR TITLE
feat: allow resuming chat via prevChat param

### DIFF
--- a/src/Controller/rag/streaming/ChatController.php
+++ b/src/Controller/rag/streaming/ChatController.php
@@ -21,17 +21,25 @@ final class ChatController extends AbstractController
     ) {}
 
     #[Route('/chat', name: 'chat', methods: ['GET'])]
-    public function chat(Request $request): Response
+    public function chat(Request $request, OpenAIResponseService $openai): Response
     {
         $session = $request->getSession();
         $session->invalidate();
 
+        $history = [];
         $prevChat = trim((string)$request->query->get('prevChat', ''));
         if ($prevChat !== '') {
             $session->set('rag_prev_response_id', $prevChat);
+            try {
+                $history = $this->buildHistory($openai, $prevChat);
+            } catch (\Throwable $e) {
+                $this->logger?->error('chat.history.fail', ['id' => $prevChat, 'error' => $e->getMessage()]);
+            }
         }
 
-        return $this->render('rag/streaming/chat/index.html.twig');
+        return $this->render('rag/streaming/chat/index.html.twig', [
+            'history' => $history,
+        ]);
     }
 
     #[Route('/chat/send-stream', name: 'chat_send_stream', methods: ['POST'])]
@@ -195,6 +203,47 @@ final class ChatController extends AbstractController
         $response->headers->set('X-Proxy-Buffering', 'off');
         $response->headers->set('X-Fastcgi-Buffering', 'off');
         return $response;
+    }
+
+    /**
+     * Build conversation history for a given final response ID.
+     *
+     * @return array<int, array{role:string,text:string}>
+     */
+    private function buildHistory(OpenAIResponseService $openai, string $id): array
+    {
+        $history = [];
+        $visited = [];
+        for ($i = 0; $i < 50 && $id !== ''; $i++) {
+            if (isset($visited[$id])) {
+                break; // avoid loops
+            }
+            $visited[$id] = true;
+            $resp = $openai->getResponse($id);
+
+            // extract user text
+            $userText = '';
+            foreach (($resp['input'][0]['content'] ?? []) as $part) {
+                if (($part['type'] ?? '') === 'input_text' && isset($part['text'])) {
+                    $userText .= (string) $part['text'];
+                }
+            }
+            $assistantText = OpenAIResponseService::extractText($resp);
+
+            if ($assistantText !== '') {
+                array_unshift($history, ['role' => 'assistant', 'text' => $assistantText]);
+            }
+            if ($userText !== '') {
+                array_unshift($history, ['role' => 'user', 'text' => $userText]);
+            }
+
+            $id = (string)($resp['previous_response_id'] ?? '');
+            if ($id === '') {
+                break;
+            }
+        }
+
+        return $history;
     }
 
     // ping removed as requested

--- a/src/Controller/rag/streaming/ChatController.php
+++ b/src/Controller/rag/streaming/ChatController.php
@@ -23,7 +23,14 @@ final class ChatController extends AbstractController
     #[Route('/chat', name: 'chat', methods: ['GET'])]
     public function chat(Request $request): Response
     {
-        $request->getSession()->invalidate();
+        $session = $request->getSession();
+        $session->invalidate();
+
+        $prevChat = trim((string)$request->query->get('prevChat', ''));
+        if ($prevChat !== '') {
+            $session->set('rag_prev_response_id', $prevChat);
+        }
+
         return $this->render('rag/streaming/chat/index.html.twig');
     }
 
@@ -134,7 +141,9 @@ final class ChatController extends AbstractController
                                 $tokensSession = (int) $session->get('rag_tokens_total', 0) + (int)$tokensQuery;
                                 $session->set('rag_tokens_total', $tokensSession);
                                 if ($finalId) { $session->set('rag_prev_response_id', $finalId); }
+                
                                 $sendEvent('done', [
+                                    'id' => $finalId,
                                     'stats' => [
                                         'tokens_query' => $tokensQuery,
                                         'tokens_answer' => $tokensAnswer,
@@ -157,6 +166,7 @@ final class ChatController extends AbstractController
                                 $session->set('rag_tokens_total', $tokensSession);
                                 if ($finalId) { $session->set('rag_prev_response_id', $finalId); }
                                 $sendEvent('done', [
+                                    'id' => $finalId,
                                     'incomplete' => true,
                                     'reason' => $reason,
                                     'stats' => [

--- a/streaming.md
+++ b/streaming.md
@@ -36,7 +36,8 @@ SSE Event Mapping
   - `response.tool_call.delta` → `tool_delta` (optional UI)
   - `response.tool_call.done` → `tool_done` (optional UI)
   - `response.error` → `error` with `{ message, insufficient_quota }`
-  - `response.completed` → `done` with `{ stats }`
+  - `response.completed` → `done` with `{ id, stats }`
+  - `response.incomplete` → `done` with `{ id, incomplete, reason, stats }`
   - App also sends an initial `meta` with `{ ping_ms }`
 
 Headers and Buffering
@@ -74,6 +75,9 @@ Logging (examples)
   - `send_stream.event_ignored`
 
 Frontend Behavior
+- Conversation persistence:
+  - Page accepts `?prevChat=<id>` to resume a conversation.
+  - Each `done` event includes the next `id`; the frontend stores it in `localStorage` and updates the URL.
 - Streaming response:
   - Shows spinner while awaiting chunks.
   - Appends `delta` tokens into a bot bubble with a blinking cursor ▌.

--- a/templates/rag/streaming/chat/index.html.twig
+++ b/templates/rag/streaming/chat/index.html.twig
@@ -49,6 +49,17 @@
 
   <script>
     (function(){
+      const params = new URLSearchParams(window.location.search);
+      const paramPrev = params.get('prevChat');
+      const storedPrev = localStorage.getItem('rag_prev_response_id');
+      if (!paramPrev && storedPrev) {
+        params.set('prevChat', storedPrev);
+        window.location.replace(window.location.pathname + '?' + params.toString());
+        return;
+      } else if (paramPrev) {
+        localStorage.setItem('rag_prev_response_id', paramPrev);
+      }
+
       const historyEl=document.getElementById('history');
       const errorEl=document.getElementById('error');
       const form=document.getElementById('chatForm');
@@ -184,6 +195,12 @@
                 errorEl.classList.remove('d-none');
               } else if(ev==='done'){
                 try{ bot.cursor.remove(); }catch{}
+                if(payload.id){
+                  localStorage.setItem('rag_prev_response_id', payload.id);
+                  const url = new URL(window.location);
+                  url.searchParams.set('prevChat', payload.id);
+                  history.replaceState(null, '', url);
+                }
               }
             }
           }

--- a/templates/rag/streaming/chat/index.html.twig
+++ b/templates/rag/streaming/chat/index.html.twig
@@ -60,6 +60,8 @@
         localStorage.setItem('rag_prev_response_id', paramPrev);
       }
 
+      const initialHistory = {{ history|json_encode|raw }};
+
       const historyEl=document.getElementById('history');
       const errorEl=document.getElementById('error');
       const form=document.getElementById('chatForm');
@@ -133,6 +135,17 @@
           }
         });
         try{ if(window.hljs) hljs.highlightAll(); }catch{}
+      }
+
+      // Render existing history on load
+      for(const msg of initialHistory){
+        if(msg.role==='user'){
+          addUserMsg(msg.text);
+        }else if(msg.role==='assistant'){
+          const bot=createBotBubble();
+          renderMarkdown(bot.content, msg.text);
+          try{bot.cursor.remove();}catch{}
+        }
       }
 
       form.addEventListener('submit',async e=>{


### PR DESCRIPTION
## Summary
- allow chat UI to resume conversations via `?prevChat=` and session seed
- send response id in streaming `done` events and persist in local storage
- document prevChat support and SSE id payload

## Testing
- `composer install` *(fails: curl error 56 CONNECT tunnel failed 403)*
- `php bin/phpunit` *(fails: Unable to find the `simple-phpunit.php` script in `vendor/symfony/phpunit-bridge/bin/`)*

------
https://chatgpt.com/codex/tasks/task_e_68b8468777dc8331a93dab5a13f44ebb